### PR TITLE
Remove provider version bump

### DIFF
--- a/.changeset/old-weeks-pump.md
+++ b/.changeset/old-weeks-pump.md
@@ -14,7 +14,6 @@
 "@igloo-ui/option-button": minor
 "@igloo-ui/pie-chart": minor
 "@igloo-ui/popover": minor
-"@igloo-ui/provider": minor
 ---
 
 Clean up non-Workleap rebranded styles for components E-P.


### PR DESCRIPTION
The provider has not changed so it does not need a bump, and is affecting other package's versions in the changeset PR