### PR TITLE
EP-6633: Fix broken css caused by redundant layer declarations

### DIFF
--- a/.changeset/itchy-frogs-push.md
+++ b/.changeset/itchy-frogs-push.md
@@ -1,0 +1,6 @@
+---
+"@igloo-ui/list": patch
+"@igloo-ui/tabs": patch
+---
+
+Fix redundant CSS layer declarations

--- a/packages/List/src/list.scss
+++ b/packages/List/src/list.scss
@@ -1,8 +1,6 @@
 @use '~@igloo-ui/tokens/dist/base10/variables' as tokens;
 @use '~@igloo-ui/tokens/dist/fonts';
 
-@layer hopper-design-system, hopper-icons, igloo;
-
 @import url('~@hopper-ui/tokens/fonts.css') layer(hopper-design-system);
 @import url('~@hopper-ui/tokens/tokens.css') layer(hopper-design-system);
 @import url("~@hopper-ui/icons-react16/index.css") layer(hopper-icons);

--- a/packages/Tabs/src/tabs.scss
+++ b/packages/Tabs/src/tabs.scss
@@ -1,8 +1,6 @@
 @use '~@igloo-ui/tokens/dist/base10/variables' as tokens;
 @use '~@igloo-ui/tokens/dist/fonts';
 
-@layer hopper-design-system, hopper-icons, igloo;
-
 @import url('~@hopper-ui/tokens/fonts.css') layer(hopper-design-system);
 @import url('~@hopper-ui/tokens/tokens.css') layer(hopper-design-system);
 @import url("~@hopper-ui/icons-react16/index.css") layer(hopper-icons);


### PR DESCRIPTION
The List and Tabs both redeclare the CSS Layers for some reason, although this is already done in globals.scss. For whatever reason the redundant declaration was resulting in the build CSS for List including the layer tag at the end with no semicolon. This produced no issues for the List itself, but when the Select used that CSS block the missing semicolon broke the CSS following it:

<img width="1070" height="323" alt="image" src="https://github.com/user-attachments/assets/61103a9e-acc2-4356-82a6-6d9e82ba7475" />

Resulting in broken select items:
<img width="550" height="186" alt="image" src="https://github.com/user-attachments/assets/904e6aae-da19-412f-89c4-021e8b434aca" />

Removing the redundant @layer fixes the built CSS